### PR TITLE
don't remount read-only after copying motifcore

### DIFF
--- a/util/motifcore_installer.py
+++ b/util/motifcore_installer.py
@@ -40,9 +40,6 @@ def install(motifcore_path, motifcore_script_path, device):
 	os.system("adb -s " + device + " push " + motifcore_path + " /system/framework")
 	os.system("adb -s " + device + " push " + motifcore_script_path + " /system/bin")
 
-	# recover permission
-	os.system("adb -s " + device + " shell mount -o ro,remount /system")
-
 
 if __name__ == "__main__":
 	os.chdir("..")


### PR DESCRIPTION
Motifcore files weren't found on my emulator after being copied, see issue #2. Removing this line fixed the problem, but is not ideal for security reasons. The temporary solution will prevent breakage for now.
