### PR TITLE
remove '-no-audio' flag

### DIFF
--- a/devices/emulator.py
+++ b/devices/emulator.py
@@ -75,10 +75,10 @@ def boot_devices():
 		print "Booting Device:", device_name
 		time.sleep(0.3)
 		if settings.HEADLESS:
-			sub.Popen('emulator -avd ' + device_name + " -wipe-data -no-audio -no-window",
+			sub.Popen('emulator -avd ' + device_name + " -wipe-data -no-window",
 					  stdout=sub.PIPE, stderr=sub.PIPE, shell=True)
 		else:
-			sub.Popen('emulator -avd ' + device_name + " -wipe-data -no-audio",
+			sub.Popen('emulator -avd ' + device_name + " -wipe-data",
 					  stdout=sub.PIPE, stderr=sub.PIPE, shell=True)
 
 	print "Waiting", settings.AVD_BOOT_DELAY, "seconds"


### PR DESCRIPTION
It was causing the following error on Arch Linux (x86_64, 4.7.0-1-ARCH):

```
qemu-system-i386: -audio: invalid option
```

sapienz runs just fine without it. Not tested with any audio-related apps.
